### PR TITLE
Refactor the logic and remove `unsafe` in the `Layer` `impl`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,10 +20,11 @@ rustdoc-args = ["--generate-link-to-definition"]
 [dependencies]
 sealed = "0.5"
 tracing = { version = "0.1.37", default-features = false }
-tracing-subscriber = { version = "0.3", features = ["registry"], default-features = false }
+tracing-subscriber = { version = "0.3", default-features = false }
 
 # Not realy used, for surviving MSRV check only.
 lazy_static = "1.1"
 
 [dev-dependencies]
 tracing = { version = "0.1", features = ["attributes", "std"], default-features = false }
+tracing-subscriber = { version = "0.3", features = ["registry"], default-features = false }

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 
 [![crates.io](https://img.shields.io/crates/v/tracing-record-hierarchical.svg "crates.io")](https://crates.io/crates/tracing-record-hierarchical)
 [![Rust 1.70+](https://img.shields.io/badge/rustc-1.70+-lightgray.svg "Rust 1.70+")](https://blog.rust-lang.org/2023/06/01/Rust-1.70.0.html)
+[![Unsafe Forbidden](https://img.shields.io/badge/unsafe-forbidden-success.svg "Unsafe forbidden")](https://github.com/rust-secure-code/safety-dance)
 [![CI](https://github.com/instrumentisto/tracing-record-hierarchical-rs/workflows/CI/badge.svg?branch=main "CI")](https://github.com/instrumentisto/tracing-record-hierarchical-rs/actions?query=workflow%3ACI+branch%3Amain)
 [![Rust docs](https://docs.rs/tracing-record-hierarchical/badge.svg "Rust docs")](https://docs.rs/tracing-record-hierarchical)
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Dealing with the complex relationship in the hierarchy of nested [`Span`]s in [`
    Which doesn't work when:
    - There is another "layer" of [`Span`]s between them;
    - The value that needs to be recorded is computed in the function (you may still be able to work around by returning from `in_scope` closure);
-   - The parent [`Span`] in question, or in another crate you have no control of.
+   - The parent [`Span`] is in another crate you have no control of.
 
 2. Bringing the parent [`Span`] to the child:
    ```rust
@@ -72,7 +72,7 @@ use tracing_record_hierarchical::HierarchicalRecord;
 
 fn init_tracing() {
     tracing_subscriber::registry()
-        .with(HierarchicalRecord::new())
+        .with(HierarchicalRecord::default())
         .init();
 }
 ```
@@ -101,7 +101,7 @@ fn bar() {
 #     use tracing_subscriber::prelude::*;
 #     use tracing_record_hierarchical::HierarchicalRecord;
 # 
-#     tracing_subscriber::registry().with(HierarchicalRecord::new()).init();
+#     tracing_subscriber::registry().with(HierarchicalRecord::default()).init();
 # 
 #     foo();
 # }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,10 +17,9 @@
     rust_2018_idioms,
     rustdoc::all,
     trivial_casts,
-    trivial_numeric_casts,
-    unsafe_code
+    trivial_numeric_casts
 )]
-#![forbid(non_ascii_idents)]
+#![forbid(non_ascii_idents, unsafe_code)]
 #![warn(
     clippy::as_conversions,
     clippy::as_ptr_cast_mut,
@@ -145,11 +144,11 @@ mod unused_deps {
     use lazy_static as _;
 }
 
-use std::{any::TypeId, fmt::Display, marker::PhantomData, ptr};
+use std::fmt::Display;
 
 use sealed::sealed;
 use tracing::{self as log, field, span, Dispatch, Metadata, Span, Subscriber};
-use tracing_subscriber::{registry::LookupSpan, Layer, Registry};
+use tracing_subscriber::{registry::LookupSpan, Layer};
 
 /// Extension of a [`tracing::Span`] providing more ergonomic handling of
 /// [`tracing::Span::record`]s.
@@ -198,7 +197,7 @@ impl SpanExt for Span {
 
 /// Records the provided `value` to the `field` of the provided [`Span`] if it
 /// has the one, otherwise tries to record it to its parent [`Span`].
-fn record<Q, V>(span: &Span, field: &Q, value: V, panic: bool)
+fn record<Q, V>(span: &Span, field: &Q, value: V, do_panic: bool)
 where
     Q: field::AsField + Display + ?Sized,
     V: field::Value,
@@ -206,184 +205,110 @@ where
     if span.has_field(field) {
         _ = span.record(field, value);
     } else {
-        record_parent(span, field, value, panic);
+        record_parent(span, field, value, do_panic);
     }
 }
 
 /// Walks up the parents' hierarchy of the provided [`Span`] and tries to record
 /// the provided `value` into the `field` of the first [`Span`] having it, or
 /// the "root" [`Span`] is reached.
-fn record_parent<Q, V>(span: &Span, field: &Q, value: V, panic: bool)
+fn record_parent<Q, V>(span: &Span, field: &Q, value: V, do_panic: bool)
 where
     Q: field::AsField + Display + ?Sized,
     V: field::Value,
 {
     _ = span.with_subscriber(|(id, dispatch)| {
-        let reg = dispatch
-            .downcast_ref::<Registry>()
-            .expect("`tracing::Subscriber` not found");
-        let ctx = dispatch.downcast_ref::<WithContext>().expect(
+        let ctx = dispatch.downcast_ref::<HierarchicalRecord>().expect(
             "add `HierarchicalRecord` `Layer` to your `tracing::Subscriber`",
         );
 
-        if let Some(span) = reg.span(id) {
-            let parent = span.scope().find_map(|parent| {
-                ctx.record_hierarchical(
-                    dispatch,
-                    &parent.id(),
-                    &|parent_id: span::Id, meta: Meta| {
-                        field
-                            .as_field(meta)
-                            .map(|field| (parent_id, meta, field))
-                    },
-                    &|| field.to_string(),
-                    panic,
-                )
-            });
-
-            if let Some((id, meta, field)) = parent {
+        if let Some((id, meta)) = ctx.with_context(
+            dispatch,
+            id,
+            &|meta: Meta| field.as_field(meta),
+            &|id, meta, field| {
                 let value: &dyn field::Value = &value;
                 dispatch.record(
-                    &id,
+                    id,
                     &span::Record::new(
                         &meta.fields().value_set(&[(&field, Some(value))]),
                     ),
                 );
-            }
-        }
+            },
+        ) {
+            // `Span` wants to record a field that has no corresponding parent.
+            // This means that we walked the entire hierarchy of `Span`s to the
+            // root, yet this field did not find it's corresponding `Span`. We
+            // know that, because otherwise the iteration in `record_parent()`
+            // would end, and this function would not be called again anymore,
+            // yet it is. Nothing to do, but report the error.
+
+            log::error!(
+                "`Span(id={id:?}, meta={meta:?})` doesn't have `{field}` field"
+            );
+            assert!(
+                !do_panic,
+                "`Span(id={id:?}, meta={meta:?})` doesn't have `{field}` field"
+            );
+        };
     });
 }
 
 /// Shortcut for a [`tracing::Span`]'s `'static` [`Metadata`].
 type Meta = &'static Metadata<'static>;
 
-/// Shortcut for [`HierarchicalRecord::with_context`]'s callback function
-/// signature.
-type WithContextCallback<'f> =
-    &'f dyn Fn(span::Id, Meta) -> Option<(span::Id, Meta, field::Field)>;
-
 /// Shortcut for a [`HierarchicalRecord::with_context`] method signature.
 type WithContextFn = fn(
     dispatch: &Dispatch,
     id: &span::Id,
-    f: WithContextCallback<'_>,
-    field: &dyn Fn() -> String,
-    panic: bool,
-) -> Option<(span::Id, Meta, field::Field)>;
-
-/// Type-erased [`Layer`]'s context.
-///
-/// This function "remembers" the type of the subscriber, so that we can
-/// downcast to something aware of them without knowing those types at the
-/// call-site.
-#[derive(Debug)]
-struct WithContext(WithContextFn);
-
-impl WithContext {
-    /// Allows a function to be called in the context of the "remembered"
-    /// subscriber.
-    fn record_hierarchical(
-        &self,
-        dispatch: &Dispatch,
-        id: &span::Id,
-        f: WithContextCallback<'_>,
-        field: &dyn Fn() -> String,
-        panic: bool,
-    ) -> Option<(span::Id, Meta, field::Field)> {
-        (self.0)(dispatch, id, f, field, panic)
-    }
-}
+    find_field: &dyn Fn(Meta) -> Option<field::Field>,
+    record: &dyn Fn(&span::Id, Meta, field::Field),
+) -> Option<(span::Id, Meta)>;
 
 /// [`Layer`] that helps [`field`]s find their corresponding [`Span`] in the
 /// hierarchy of [`Span`]s.
-#[derive(Debug)]
-pub struct HierarchicalRecord<S> {
-    /// Type-erased [`Layer`]'s context.
-    ctx: WithContext,
-
-    /// [`Subscriber`]'s type.
-    _subscriber: PhantomData<fn(S)>,
+#[derive(Debug, Default, Clone, Copy)]
+pub struct HierarchicalRecord {
+    /// This function "remembers" the type of the subscriber, so that we can do
+    /// something aware of them without knowing those types at the call-site.
+    with_context: Option<WithContextFn>,
 }
 
-impl<S> Default for HierarchicalRecord<S>
-where
-    S: for<'span> LookupSpan<'span> + Subscriber,
-{
-    fn default() -> Self {
-        Self::new()
-    }
-}
-
-impl<S> HierarchicalRecord<S>
-where
-    S: for<'span> LookupSpan<'span> + Subscriber,
-{
-    /// Creates a new [`HierarchicalRecord`].
-    #[must_use]
-    pub fn new() -> Self {
-        Self { ctx: WithContext(Self::with_context), _subscriber: PhantomData }
-    }
-
-    /// Function saved and called by a [`WithContext`] at the call-site.
-    #[allow(clippy::unwrap_in_result)]
+impl HierarchicalRecord {
+    /// Allows a function to be called in the context of the "remembered"
+    /// subscriber.
     fn with_context(
+        self,
         dispatch: &Dispatch,
         id: &span::Id,
-        f: WithContextCallback<'_>,
-        field: &dyn Fn() -> String,
-        do_panic: bool,
-    ) -> Option<(span::Id, Meta, field::Field)> {
-        let subscriber = dispatch
-            .downcast_ref::<S>()
-            .expect("`tracing::Subscriber` not found");
-        let span = subscriber.span(id).expect("unknown `tracing::Span`");
-
-        #[allow(clippy::option_if_let_else)]
-        if let Some(parent) = span.parent() {
-            f(parent.id(), parent.metadata())
-        } else {
-            // `Span` wants to record a field but has no parents. This means
-            // that we walked the entire hierarchy of `Span`s to the root, yet
-            // this field did not find it's corresponding `Span`. We know that,
-            // because otherwise the iteration in `record_parent()` would end,
-            // and this function would not be called again anymore, yet it is.
-            // Nothing to do, but report the error.
-
-            let meta = span.metadata();
-            let field = field();
-
-            // We log and then panic to avoid situation, when we get double
-            // panic without any info.
-            log::error!(
-                "`Span(id={id:?}, meta={meta:?})` doesn't have `{field}` field"
-            );
-            do_panic.then(|| {
-                panic!(
-                    "`Span(id={id:?}, meta={meta:?})` doesn't have `{field}` \
-                     field",
-                )
-            })
-        }
+        find_field: &dyn Fn(Meta) -> Option<field::Field>,
+        record: &dyn Fn(&span::Id, Meta, field::Field),
+    ) -> Option<(span::Id, Meta)> {
+        (self.with_context?)(dispatch, id, find_field, record)
     }
 }
 
-impl<S> Layer<S> for HierarchicalRecord<S>
+impl<S> Layer<S> for HierarchicalRecord
 where
     S: for<'span> LookupSpan<'span> + Subscriber,
 {
-    // SAFETY: This is safe because the `WithContext` function pointer is valid
-    //         for the lifetime of `&self`.
-    #[allow(unsafe_code)]
-    unsafe fn downcast_raw(&self, id: TypeId) -> Option<*const ()> {
-        match id {
-            id if id == TypeId::of::<Self>() => {
-                Some(ptr::addr_of!(self).cast::<()>())
+    fn on_layer(&mut self, _: &mut S) {
+        self.with_context = Some(|dispatch, id, find_field, record| {
+            let subscriber = dispatch.downcast_ref::<S>()?;
+            let span = subscriber.span(id)?;
+
+            let field = span.parent().and_then(|parent| {
+                parent.scope().find_map(|s| find_field(s.metadata()))
+            });
+
+            #[allow(clippy::option_if_let_else)]
+            if let Some(field) = field {
+                record(&span.id(), span.metadata(), field);
+                None
+            } else {
+                Some((span.id(), span.metadata()))
             }
-            id if id == TypeId::of::<WithContext>() => {
-                Some(ptr::addr_of!(self.ctx).cast::<()>())
-            }
-            _ => None,
-        }
+        });
     }
 }
 
@@ -395,7 +320,7 @@ mod spec {
         use tracing_subscriber::layer::SubscriberExt as _;
 
         tracing::subscriber::with_default(
-            tracing_subscriber::registry().with(HierarchicalRecord::new()),
+            tracing_subscriber::registry().with(HierarchicalRecord::default()),
             f,
         );
     }
@@ -489,6 +414,16 @@ mod spec {
                     _ = Span::current()
                         .must_record_hierarchical("field", "value");
                 });
+            });
+        });
+    }
+
+    #[test]
+    #[should_panic = "doesn't have `field` field"]
+    fn must_panics_on_missing_field_and_no_parents() {
+        with_subscriber(|| {
+            tracing::info_span!("child").in_scope(|| {
+                _ = Span::current().must_record_hierarchical("field", "value");
             });
         });
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -265,7 +265,7 @@ type WithContextFn = fn(
     record: &dyn Fn(&span::Id, Meta, field::Field),
 ) -> Option<(span::Id, Meta)>;
 
-/// [`Layer`] that helps [`field`]s find their corresponding [`Span`] in the
+/// [`Layer`] helping [`field`]s to find their corresponding [`Span`] in the
 /// hierarchy of [`Span`]s.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct HierarchicalRecord {


### PR DESCRIPTION
Resolves https://github.com/instrumentisto/tracing-record-hierarchical-rs/pull/1#discussion_r1331884010
Related to https://github.com/instrumentisto/tracing-record-hierarchical-rs/pull/1#discussion_r1331884010


## Synopsis

As addressed by @tyranron in https://github.com/instrumentisto/tracing-record-hierarchical-rs/pull/1#discussion_r1331884010, `unsafe` is used, but it doesn't have to be.

## Solution

As it turns out, there is a way to reference the `tracing::Subscriber` on the call-site without implementing `Layer::downcast_raw` `unsafe` `doc(hidden)` method. As a bonus, after the refactor, the code turned out easier to read and understand, I think. Also, we no longer require `Registry` `Subscriber` to be used.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests