### PR TITLE
Fix recording a field in the parent spans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,14 +6,14 @@ All user visible changes to this project will be documented in this file. This p
 
 
 
-## [0.1.1] · 2023-??-?? (unreleased)
+## [0.1.1] · 2023-12-04
 [0.1.1]: /../../tree/v0.1.1
 
-[Diff](https://github.com/instrumentisto/tracing-record-hierarchical/compare/tracing-record-hierarchical-0.1.0...tracing-record-hierarchical-0.1.1)
+[Diff](/../../compare/v0.1.0...v0.1.1)
 
 ### Fixed
 
-- Recording of fields to parent `tracing::Span`s (#4).
+- Recording of fields to parent `tracing::Span`s. ([#4])
 
 [#4]: /../../pull/4
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-record-hierarchical"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 rust-version = "1.70"
 description = "Record parent `tracing::Span` fields from inside child `tracing::Span`'s context."


### PR DESCRIPTION

## Synopsis

Due to [somewhat undocumented behavior](https://docs.rs/tracing-core/0.1.32/src/tracing_core/field.rs.html#1002) in the `tracing` crate, it was assumed that field recording logic from this crate is correct. Our tests never checked the value of the field after `record`ing it, and there were no `panic`s. 

## Solution

Fix the flaw in the parent field recording logic.
Add tests that make sure we are indeed recording the field.

## Checklist

- Created PR:
    - [x] In [draft mode][l:1]
    - [x] Name contains issue reference
    - [x] Has type and `k::` labels applied
    - [x] Has assignee
- Before [review][l:4]:
    - [x] Documentation is updated (if required)
    - [x] Tests are updated (if required)
    - [x] Changes conform [code style][l:2]
    - [x] [CHANGELOG entry][l:3] is added (if required)
    - [x] FCM (final commit message) is posted or updated
    - [x] [Draft mode][l:1] is removed
- [x] [Review][l:4] is completed and changes are approved
    - [x] FCM (final commit message) is approved
- Before merge:
    - [x] Milestone is set
    - [x] PR's name and description are correct and up-to-date
    - [x] All temporary labels are removed




[l:1]: https://help.github.com/en/articles/about-pull-requests#draft-pull-requests
[l:2]: /CONTRIBUTING.md#code-style
[l:3]: /CHANGELOG.md
[l:4]: https://help.github.com/en/articles/reviewing-changes-in-pull-requests